### PR TITLE
Remove hardcoded credentials

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -1,4 +1,7 @@
 if File.exists?("spec/ldap_config.yml")
+  puts "Note from local .irbrc:"
+  puts "Loading and configuring LDAP config from spec/ldap_config.yml"
+  puts "This is using ucb_ldap as an installed gem - this might not be what you want."
   require "rubygems"
   require "yaml"
   require "ucb_ldap"

--- a/lib/ucb_ldap/org.rb
+++ b/lib/ucb_ldap/org.rb
@@ -327,14 +327,9 @@ module UCB
           return @all_nodes if @all_nodes
           return nodes_from_test_cache if $TESTING && @test_node_cache
 
-          tree_username = "uid=istaswa-ruby,ou=applications,dc=berkeley,dc=edu"
-          tree_password = "t00lBox12"
-
-          UCB::LDAP.with_credentials(tree_username, tree_password) do
-            @all_nodes = search.inject({}) do |accum, org|
-              accum[org.deptid] = org if org.deptid != "Org Units"
-              accum
-            end
+          @all_nodes = search.inject({}) do |accum, org|
+            accum[org.deptid] = org if org.deptid != "Org Units"
+            accum
           end
 
           build_test_node_cache if $TESTING

--- a/lib/ucb_ldap/version.rb
+++ b/lib/ucb_ldap/version.rb
@@ -1,3 +1,3 @@
 module UcbLdap
-  VERSION = "3.0.0"
+  VERSION = "3.1.0"
 end


### PR DESCRIPTION
This one method was using hard-coded credentials rather than the globally-configured credentials, for reasons that aren't at all clear. I can only guess that it might have needed a privileged bind.

I tested this from a client app, and the call still seemed to work correctly after this change.