### PR TITLE
Switch to new default LDAP server

### DIFF
--- a/lib/ucb_ldap.rb
+++ b/lib/ucb_ldap.rb
@@ -56,7 +56,7 @@ module UCB
     end
 
 
-    HOST_PRODUCTION = 'nds.berkeley.edu'
+    HOST_PRODUCTION = 'ldap.berkeley.edu'
 
     class << self
       # Execute UCB::LDAP commands with a different username and password.

--- a/spec/ldap_config.yml.example
+++ b/spec/ldap_config.yml.example
@@ -1,5 +1,5 @@
  ldap:
-   host: nds.berkeley.edu
+   host: ldap.berkeley.edu
    username:
    password:
    include_test_entries: true


### PR DESCRIPTION
We're switching the default LDAP server from `nds.berkeley.edu` to `ldap.berkeley.edu`

Note that individual apps that have overridden the default config will need to make this change in their config files.