### PR TITLE
Remove case-sensitive match for top-level node name

### DIFF
--- a/lib/ucb_ldap/org.rb
+++ b/lib/ucb_ldap/org.rb
@@ -382,7 +382,7 @@ module UCB
         def calculate_all_child_nodes
           @all_nodes.values.each { |node| node.init_child_nodes }
           @all_nodes.values.each do |node|
-            next if node.deptid == 'UCBKL' || node.deptid == "Org Units"
+            next if node.deptid == 'UCBKL' || node.deptid.downcase == "org units"
             parent_node = find_by_ou_from_cache(node.parent_deptids.last)
             parent_node.push_child_node(node)
           end


### PR DESCRIPTION
When fetching org units from LDAP, we get a top-level node that used to be called "Org Units" but it is now called "org units". The code that looked for this special node was executing a case-sensitive match, causing it to fail. 