### PR TITLE
📪 Update Berkeley email field - bump to version 3.1.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # UCB::LDAP Changelog
 
+## Version 3.1.4, May 6, 2024
+* Move from berkeleyEduOfficialEmail to berkeleyAlternateId as source for officialemail and ucbemail
+
 ## Version 3.1.3, March 8, 2023
 * Switch to latest version of net-ldap
 

--- a/lib/ucb_ldap/person/common_attributes.rb
+++ b/lib/ucb_ldap/person/common_attributes.rb
@@ -28,7 +28,7 @@ module UCB
       end
 
       def officialemail
-        berkeleyEduOfficialEmail.first
+        berkeleyEduAlternateId.first
       end
 
       def phone

--- a/lib/ucb_ldap/version.rb
+++ b/lib/ucb_ldap/version.rb
@@ -1,3 +1,3 @@
 module UcbLdap
-  VERSION = "3.1.3"
+  VERSION = "3.1.4"
 end

--- a/schema/schema.yml
+++ b/schema/schema.yml
@@ -1285,7 +1285,7 @@ person:
       objectClass: berkeleyEduPerson
       required: false
       syntax: string
-    berkeleyEduOfficialEmail:
+    berkeleyEduAlternateId:
       aliases:
         - ucbemail
       description: 'Email Addresses'


### PR DESCRIPTION
This moves away from the deprecated berkeleyEduOfficialEmail field and to the recommended berkeleyEduAlternateId field. Email with recommendation from bConnected attached.

Wed, May 1, 9:29 AM
Hi Cosmo,

As Jeffrey mentioned in our separate thread, eventually those two fields will be merged, but berkeleyEduAlternateID is best because it is the primary Google account address associated with every person's CalNetID.

...

Jon Hays
Manager, Communication and Collaboration Services